### PR TITLE
[TASK] Script Implementation for assigning permissions to the Access Keys for bucket access

### DIFF
--- a/example-configuration.json
+++ b/example-configuration.json
@@ -23,8 +23,8 @@
 				{
 					"bucket": "postgresql",
 					"owner": true,
-					"reader": true,
-					"writer": true
+					"read": true,
+					"write": true
 				}
 			]
 		},
@@ -35,14 +35,26 @@
 				{
 					"bucket": "postgresql",
 					"owner": true,
-					"reader": true,
-					"writer": true
+					"read": true,
+					"write": true
 				},
 				{
 					"bucket": "cloud",
 					"owner": true,
-					"reader": true,
-					"writer": true
+					"read": true,
+					"write": true
+				}
+			]
+		},
+		{
+			"name": "cloud",
+			"createBucket": true,
+			"permissions": [
+				{
+					"bucket": "cloud",
+					"owner": true,
+					"read": true,
+					"write": true
 				}
 			]
 		}

--- a/example-configuration.json
+++ b/example-configuration.json
@@ -2,6 +2,7 @@
 	"adminApiUrl": "https://localhost:3943",
 	"k8sClusterName": "garage",
 	"k8sClusterNamespace": "garage",
+	"region": "garage",
 	"desiredReplicas": 3,
 	"nodeTags": ["garage", "node"],
 	"buckets": ["postgresql", "cloud"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import type { UpdateClusterLayoutDto } from "./utilities/garage/cluster";
 let GARAGE_ADMIN_API_URL = "http://localhost:3903";
 let GARAGE_KUBERNETES_CLUSTER_NAME = "garage";
 let GARAGE_KUBERNETES_NAMESPACE = "garage";
+let GARAGE_CLUSTER_REGION_NAME = "garage";
 let GARAGE_KUBERNETES_DESIRED_REPLICAS = 1;
 let GARAGE_STORAGE_PER_NODE_IN_GBS = 1;
 let GARAGE_STORAGE_NODE_TAGS: Array<string> = [];
@@ -64,6 +65,8 @@ async function readAndSetConfiguration() {
 		configuratorJson["k8sClusterName"] ?? GARAGE_KUBERNETES_CLUSTER_NAME;
 	GARAGE_KUBERNETES_NAMESPACE =
 		configuratorJson["k8sClusterNamespace"] ?? GARAGE_KUBERNETES_NAMESPACE;
+	GARAGE_CLUSTER_REGION_NAME =
+		configuratorJson["region"] ?? GARAGE_CLUSTER_REGION_NAME;
 	GARAGE_KUBERNETES_DESIRED_REPLICAS =
 		Number(configuratorJson["desiredReplicas"]) ??
 		GARAGE_KUBERNETES_DESIRED_REPLICAS;
@@ -377,6 +380,7 @@ async function createAccessKeySecrets() {
 					SECRET_ACCESS_KEY: Buffer.from(
 						keysInfo[accessKey["name"]]["secretAccessKey"],
 					).toString("base64"),
+					S3_REGION: Buffer.from(GARAGE_CLUSTER_REGION_NAME).toString("base64"),
 				},
 			);
 

--- a/src/utilities/garage/keys.ts
+++ b/src/utilities/garage/keys.ts
@@ -35,7 +35,9 @@ export async function createKey(
 		body: JSON.stringify({
 			name,
 			neverExpires,
-			createBucket,
+			allow: {
+				createBucket,
+			},
 		}),
 	});
 

--- a/src/utilities/garage/permissions.ts
+++ b/src/utilities/garage/permissions.ts
@@ -1,0 +1,25 @@
+// Method to assign keys permissions to the bucket
+export async function assignPermissionsToAccessKeys(
+	garageAdminApiUrl: string,
+	accessKeyId: string,
+	bucketId: string,
+	permissions: { owner: boolean; read: boolean; write: boolean },
+) {
+	const response = await fetch(`${garageAdminApiUrl}/v2/AllowBucketKey`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${process.env.GARAGE_ADMIN_TOKEN}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			accessKeyId,
+			bucketId,
+			permissions,
+		}),
+	});
+
+	return {
+		status: response.ok ? "success" : "error",
+		response: await response.json(),
+	};
+}


### PR DESCRIPTION
# Implemented Changes
- Script Implementation for assigning permissions to the Access Keys for bucket access
- Runs after all keys and buckets have been created
- **API Routes used:** `POST /v2/AllowBucketKey`

**Closes: #5**
